### PR TITLE
Use ICU build of qbittorrent-nox

### DIFF
--- a/linux-amd64.Dockerfile
+++ b/linux-amd64.Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/ma
 
 ARG QBITTORRENT_FULL_VERSION
 
-RUN curl -fsSL "https://github.com/userdocs/qbittorrent-nox-static/releases/download/${QBITTORRENT_FULL_VERSION}/x86_64-qbittorrent-nox" > "${APP_DIR}/qbittorrent-nox" && \
+RUN curl -fsSL "https://github.com/userdocs/qbittorrent-nox-static/releases/download/${QBITTORRENT_FULL_VERSION}/x86_64-icu-qbittorrent-nox" > "${APP_DIR}/qbittorrent-nox" && \
     chmod 755 "${APP_DIR}/qbittorrent-nox"
 
 ARG FLOOD_VERSION

--- a/linux-arm64.Dockerfile
+++ b/linux-arm64.Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/ma
 
 ARG QBITTORRENT_FULL_VERSION
 
-RUN curl -fsSL "https://github.com/userdocs/qbittorrent-nox-static/releases/download/${QBITTORRENT_FULL_VERSION}/aarch64-qbittorrent-nox" > "${APP_DIR}/qbittorrent-nox" && \
+RUN curl -fsSL "https://github.com/userdocs/qbittorrent-nox-static/releases/download/${QBITTORRENT_FULL_VERSION}/aarch64-icu-qbittorrent-nox" > "${APP_DIR}/qbittorrent-nox" && \
     chmod 755 "${APP_DIR}/qbittorrent-nox"
 
 ARG FLOOD_VERSION


### PR DESCRIPTION
With the build of qbittorrent-nox without ICU, Qbittorrent version post 4.4.0 get spammed with 

```
Numeric mode unsupported in the posix collation implementatio
```

The ICU version solves this issue